### PR TITLE
fixed empty ongoing-anime list(#10)

### DIFF
--- a/controllers/index.controller.js
+++ b/controllers/index.controller.js
@@ -113,15 +113,18 @@ const RenderHomePage = async (req, res, next) => {
     mangass = await mangaParkObj.getMangaList(1);
     const mangaUpdateList = mangass.LatestManga;
 
-    res.render("index", {
-        title: "Mirai",
-        navList: navList,
-        updateList: updateList,
-        mangaUpdateList: mangaUpdateList,
-        newAnimeList: newAnimeList,
-        popularList: popularList,
-        ongoingList: ongoingList,
-    });
+    setTimeout(function(){
+        res.render("index", {
+            title: "Mirai",
+            navList: navList,
+            updateList: updateList,
+            mangaUpdateList: mangaUpdateList,
+            newAnimeList: newAnimeList,
+            popularList: popularList,
+            ongoingList: ongoingList,
+        });
+    }, 
+    3000);
 };
 
 module.exports = RenderHomePage;


### PR DESCRIPTION
**Linked issue:** #10

**Changes**
After doing a lot of brainstorming, I finally found a simple hack to fix the empty ongoing list issue.
Just by adding a timeout of 3 seconds before rendering the home page, the cheerio and request functions are able to load the data completely before being passed to the frontend script.

**Note**
PR #14 had some previous commits added due to some error. This is a revised PR for the same changes with those commits removed. Merging #15 will merge this PR automatically.

**Screenshot for reference**
![image](https://user-images.githubusercontent.com/52620158/112278234-9eb52c80-8ca8-11eb-9936-8f1eacade7e8.png)
