### PR TITLE
Replace usage of request library with node-fetch

### DIFF
--- a/controllers/index.controller.js
+++ b/controllers/index.controller.js
@@ -1,4 +1,4 @@
-const request = require("request");
+const fetch = require("node-fetch");
 const cheerio = require("cheerio");
 const mangaPark = require("../utils/mangapark");
 const mangaParkObj = new mangaPark();
@@ -12,36 +12,47 @@ const RenderHomePage = async (req, res, next) => {
         var ongoingList = [];
 
         // Fetch Gogoanime popular anime links
-        request(
-            "https://www.gogoanime1.com/home/popular-animes",
-            (error, response, html) => {
-                if (!error && response.statusCode == 200) {
-                    const $ = cheerio.load(html);
-
-                    $(".big-list .wide-anime-box").each((i, el) => {
-                        var anime = {};
-                        var genre = [];
-                        anime.picture = $(el).find(".anime-image").attr("style");
-                        anime.link = $(el).find(".anime-image").attr("href");
-                        anime.name = $(el).find(".wab-title a").text();
-                        anime.description = $(el).find(".wab-desc").text();
-                        $(el)
-                            .find(".wab-links a")
-                            .each((j, ex) => {
-                                genre.push($(ex).text());
-                            });
-                        anime.genre = genre;
-                        popularList.push(anime);
-                    });
+        fetch("https://www.gogoanime1.com/home/popular-animes")
+            .then(response => {
+                if(response.ok) {   // response.status >= 200 & < 300
+                    return response.text();
                 } else {
-                    console.log(error);
+                    throw Error(response.statusText);
                 }
-            }
-        );
+            })
+            .then(html => {
+                const $ = cheerio.load(html);
+
+                $(".big-list .wide-anime-box").each((i, el) => {
+                    var anime = {};
+                    var genre = [];
+                    anime.picture = $(el).find(".anime-image").attr("style");
+                    anime.link = $(el).find(".anime-image").attr("href");
+                    anime.name = $(el).find(".wab-title a").text();
+                    anime.description = $(el).find(".wab-desc").text();
+                    $(el)
+                        .find(".wab-links a")
+                        .each((j, ex) => {
+                            genre.push($(ex).text());
+                        });
+                    anime.genre = genre;
+                    popularList.push(anime);
+                });
+            })
+            .catch(err => {
+                console.error(err);
+            })
 
         // Fetch Gogoanime latest up[date] links
-        request("https://www.gogoanime1.com", (error, response, html) => {
-            if (!error && response.statusCode == 200) {
+        fetch("https://www.gogoanime1.com")
+            .then(response => {
+                if(response.ok) {   // response.status >= 200 & < 300
+                    return response.text();
+                } else {
+                    throw Error(response.statusText);
+                }
+            })
+            .then(html => {
                 const $ = cheerio.load(html);
 
                 $(".main-menu li").each((i, el) => {
@@ -75,41 +86,45 @@ const RenderHomePage = async (req, res, next) => {
                     newanime.genre = genre;
                     newAnimeList.push(newanime);
                 });
-            } else {
-                console.log(error);
-            }
-        });
+            })
+            .catch(err => {
+                console.error(err);
+            })
 
         // Fetch Gogoanime latest up[date] links
-        request(
-            "https://www.gogoanime1.com/home/ongoing",
-            (error, response, html) => {
-                if (!error && response.statusCode == 200) {
-                    const $ = cheerio.load(html);
-
-                    $(".big-list .bl-grid").each((i, el) => {
-                        var ongoing = {};
-                        var genre = [];
-                        ongoing.mainLink = $(el).find(".blb-image").attr("href");
-                        ongoing.imageLink = $(el).find(".blb-image img").attr("src");
-                        ongoing.title = $(el).find(".blb-title").text();
-                        console.log(ongoing);
-                        $(el)
-                            .find(".blb-links a")
-                            .each((j, elj) => {
-                                if (j <= 20) {
-                                    genre.push($(elj).text());
-                                }
-                            });
-                        ongoing.genre = genre;
-                        ongoingList.push(ongoing);
-                    });
-                    console.log(ongoingList);
+        fetch("https://www.gogoanime1.com/home/ongoing")
+            .then(response => {
+                if(response.ok) {   // response.status >= 200 & < 300
+                    return response.text();
                 } else {
-                    console.log(error);
+                    throw Error(response.statusText);
                 }
-            }
-        );
+            })
+            .then(html => {
+                const $ = cheerio.load(html);
+
+                $(".big-list .bl-grid").each((i, el) => {
+                    var ongoing = {};
+                    var genre = [];
+                    ongoing.mainLink = $(el).find(".blb-image").attr("href");
+                    ongoing.imageLink = $(el).find(".blb-image img").attr("src");
+                    ongoing.title = $(el).find(".blb-title").text();
+                    console.log(ongoing);
+                    $(el)
+                        .find(".blb-links a")
+                        .each((j, elj) => {
+                            if (j <= 20) {
+                                genre.push($(elj).text());
+                            }
+                        });
+                    ongoing.genre = genre;
+                    ongoingList.push(ongoing);
+                });
+                console.log(ongoingList);
+            })
+            .catch(err => {
+                console.error(err);
+            })
 
         mangass = await mangaParkObj.getMangaList(1);
         const mangaUpdateList = mangass.LatestManga;

--- a/controllers/loader.controller.js
+++ b/controllers/loader.controller.js
@@ -1,12 +1,19 @@
-const request = require("request");
+const fetch = require("node-fetch");
 const cheerio = require("cheerio");
 
 let seriesDetails = {};
 let navList = [];
 
 // Fetch Gogoanime latest header links
-request("https://www.gogoanime1.com", (error, response, html) => {
-    if (!error && response.statusCode == 200) {
+fetch("https://www.gogoanime1.com")
+    .then(response => {
+        if (response.ok) {   // response.status >= 200 & < 300
+            return response.text();
+        } else {
+            throw Error(response.statusText);
+        }
+    })
+    .then(html => {
         const $ = cheerio.load(html);
 
         $(".main-menu li").each((i, el) => {
@@ -15,179 +22,191 @@ request("https://www.gogoanime1.com", (error, response, html) => {
             link.text = $(el).find("a").text();
             navList.push(link);
         });
-    } else {
-        console.log(error);
-    }
-});
+    })
+    .catch(err => {
+        console.error(err);
+    })
 
 const RenderAnimeList = (req, res, next) => {
-    try{
-        const url = req.query.url;
-        let series = [];
-        request(url, (error, response, html) => {
-            if (!error && response.statusCode == 200) {
-                const $ = cheerio.load(html);
-
-                $(".container-left .container-item").each((i, el) => {
-                    let index = $(el).find(".ci-title").text();
-                    let linkstoindex = $(el).find("li");
-
-                    let links = [];
-                    linkstoindex.each((j, elx) => {
-                        let info = {};
-                        info.href = $(elx).find("a").attr("href");
-                        info.text = $(elx).find("a").text();
-                        links.push(info);
-                    });
-
-                    series.push({ index, links });
-                });
-                res.render("animelist", { title: "Mirai", series: series });
+    const url = req.query.url;
+    let series = [];
+    fetch(url)
+        .then(response => {
+            if (response.ok) {   // response.status >= 200 & < 300
+                return response.text();
             } else {
-                console.log(error);
+                throw Error(response.statusText);
             }
-        });
-    }
-    catch(err){
-        console.log(err);
-    }
+        })
+        .then(html => {
+            const $ = cheerio.load(html);
+
+            $(".container-left .container-item").each((i, el) => {
+                let index = $(el).find(".ci-title").text();
+                let linkstoindex = $(el).find("li");
+
+                let links = [];
+                linkstoindex.each((j, elx) => {
+                    let info = {};
+                    info.href = $(elx).find("a").attr("href");
+                    info.text = $(elx).find("a").text();
+                    links.push(info);
+                });
+
+                series.push({ index, links });
+            });
+            res.render("animelist", { title: "Mirai", series: series });
+        })
+        .catch(err => {
+            console.error(err);
+            res.sendStatus(err.status || 500);
+        })
 };
 
 const LoaderController = (req, res, next) => {
-    try{
-        let latestk = [];
-        let url = req.body.link;
-        request(url, (error, response, html) => {
-            if (!error && response.statusCode == 200) {
-                const $ = cheerio.load(html);
-                $(".truyen-list .list-truyen-item-wrap").each((j, eld) => {
-                    let item = {};
-                    item.mangaLink = $(eld).children().first("a").attr("href");
-                    item.imageLink = $(eld).find("img").attr("src");
-                    item.views = $(eld).find(".aye_icon").text();
-                    item.description = $(eld).find("p").text();
-                    item.title = $(eld).find("h3 a").text();
-                    item.update = $(eld).find(".list-story-item-wrap-chapter").text();
-                    item.updateLink = $(eld)
-                        .find(".list-story-item-wrap-chapter")
-                        .attr("href");
-                    latestk.push(item);
-                });
-                let total = $(".panel_page_number .group_qty").find("a").text();
-                let linksk = [];
-                $(".panel_page_number .group_page a").each((y, elx) => {
-                    let link = {};
-                    link.text = $(elx).text();
-                    link.href = $(elx).attr("href");
-                    link.class = $(elx).attr("class");
-                    linksk.push(link);
-                });
-
-                res.render("latest", {
-                    title: "Mirai",
-                    latest: latestk,
-                    total: total,
-                    links: linksk,
-                });
+    let latestk = [];
+    let url = req.body.link;
+    fetch(url)
+        .then(response => {
+            if (response.ok) {   // response.status >= 200 & < 300
+                return response.text();
             } else {
-                console.log(error);
+                throw Error(response.statusText);
             }
-        });
-    }
-    catch(err){
-        console.log(err);
-    }
+        })
+        .then(html => {
+            const $ = cheerio.load(html);
+            $(".truyen-list .list-truyen-item-wrap").each((j, eld) => {
+                let item = {};
+                item.mangaLink = $(eld).children().first("a").attr("href");
+                item.imageLink = $(eld).find("img").attr("src");
+                item.views = $(eld).find(".aye_icon").text();
+                item.description = $(eld).find("p").text();
+                item.title = $(eld).find("h3 a").text();
+                item.update = $(eld).find(".list-story-item-wrap-chapter").text();
+                item.updateLink = $(eld)
+                    .find(".list-story-item-wrap-chapter")
+                    .attr("href");
+                latestk.push(item);
+            });
+            let total = $(".panel_page_number .group_qty").find("a").text();
+            let linksk = [];
+            $(".panel_page_number .group_page a").each((y, elx) => {
+                let link = {};
+                link.text = $(elx).text();
+                link.href = $(elx).attr("href");
+                link.class = $(elx).attr("class");
+                linksk.push(link);
+            });
+
+            res.render("latest", {
+                title: "Mirai",
+                latest: latestk,
+                total: total,
+                links: linksk,
+            });
+        })
+        .catch(err => {
+            console.error(err);
+            res.sendStatus(err.status || 500);
+        })
 };
 
 const RenderLoadEpisodes = (req, res, next) => {
-    try{
-        let url = req.query.url;
-        let episodeList = [];
-        let detailer = [];
-        request(url, (error, response, html) => {
-            if (!error && response.statusCode == 200) {
-                const $ = cheerio.load(html);
-                //Get series details
-                seriesDetails.name = $(".anime-title").text();
-                seriesDetails.details = $(".anime-details").text();
-                seriesDetails.image = $(".animeDetail-image").find("img").attr("src");
-                seriesDetails.started = $(".animeDetail-tags").children().last().text();
-                $(".animeDetail-tags .animeDetail-item").each((i, el) => {
-                    let detailsx = {};
-                    detailsx.name = $(el).find("span").text();
-                    detailsx.value = $(el).text();
-                    detailer.push(detailsx);
-                });
-                //Get episodes list and links
-                let episodeDiv = $(".tnContent").attr("style", "display: none;");
-                episodeDiv.find("li").each((i, el) => {
-                    let link = {};
-                    link.href = $(el).find("a").attr("href");
-                    link.episode = $(el).find("a").text();
-                    episodeList.push(link);
-                });
-
-                res.render("loadepisode", {
-                    title: "Mirai",
-                    navList: navList,
-                    episodeList: episodeList,
-                    seriesDetails: seriesDetails,
-                    detailer: detailer,
-                });
+    let url = req.query.url;
+    let episodeList = [];
+    let detailer = [];
+    fetch(url)
+        .then(response => {
+            if (response.ok) {   // response.status >= 200 & < 300
+                return response.text();
             } else {
-                console.log(error);
+                throw Error(response.statusText);
             }
-        });
-    }
-    catch(err){
-        console.log(err);
-    }
+        })
+        .then(html => {
+            const $ = cheerio.load(html);
+            //Get series details
+            seriesDetails.name = $(".anime-title").text();
+            seriesDetails.details = $(".anime-details").text();
+            seriesDetails.image = $(".animeDetail-image").find("img").attr("src");
+            seriesDetails.started = $(".animeDetail-tags").children().last().text();
+            $(".animeDetail-tags .animeDetail-item").each((i, el) => {
+                let detailsx = {};
+                detailsx.name = $(el).find("span").text();
+                detailsx.value = $(el).text();
+                detailer.push(detailsx);
+            });
+            //Get episodes list and links
+            let episodeDiv = $(".tnContent").attr("style", "display: none;");
+            episodeDiv.find("li").each((i, el) => {
+                let link = {};
+                link.href = $(el).find("a").attr("href");
+                link.episode = $(el).find("a").text();
+                episodeList.push(link);
+            });
+
+            res.render("loadepisode", {
+                title: "Mirai",
+                navList: navList,
+                episodeList: episodeList,
+                seriesDetails: seriesDetails,
+                detailer: detailer,
+            });
+        })
+        .catch(err => {
+            console.error(err);
+            res.sendStatus(err.status || 500);
+        })
 };
 
 const RenderNewLoader = (req, res, next) => {
-    try{
-        let latestk = [];
-        let url = req.body.link;
-        request(url, (error, response, html) => {
-            if (!error && response.statusCode == 200) {
-                const $ = cheerio.load(html);
-                $(".truyen-list .list-truyen-item-wrap").each((j, eld) => {
-                    let item = {};
-                    item.mangaLink = $(eld).children().first("a").attr("href");
-                    item.imageLink = $(eld).find("img").attr("src");
-                    item.views = $(eld).find(".aye_icon").text();
-                    item.description = $(eld).find("p").text();
-                    item.title = $(eld).find("h3 a").text();
-                    item.update = $(eld).find(".list-story-item-wrap-chapter").text();
-                    item.updateLink = $(eld)
-                        .find(".list-story-item-wrap-chapter")
-                        .attr("href");
-                    latestk.push(item);
-                });
-                let total = $(".panel_page_number .group_qty").find("a").text();
-                let linksk = [];
-                $(".panel_page_number .group_page a").each((y, elx) => {
-                    let link = {};
-                    link.text = $(elx).text();
-                    link.href = $(elx).attr("href");
-                    link.class = $(elx).attr("class");
-                    linksk.push(link);
-                });
-
-                res.render("newloader", {
-                    title: "Mirai",
-                    latest: latestk,
-                    total: total,
-                    links: linksk,
-                });
+    let latestk = [];
+    let url = req.body.link;
+    fetch(url)
+        .then(response => {
+            if (response.ok) {   // response.status >= 200 & < 300
+                return response.text();
             } else {
-                console.log(error);
+                throw Error(response.statusText);
             }
-        });
-    }
-    catch(err){
-        console.log(err);
-    }
+        })
+        .then(html => {
+            const $ = cheerio.load(html);
+            $(".truyen-list .list-truyen-item-wrap").each((j, eld) => {
+                let item = {};
+                item.mangaLink = $(eld).children().first("a").attr("href");
+                item.imageLink = $(eld).find("img").attr("src");
+                item.views = $(eld).find(".aye_icon").text();
+                item.description = $(eld).find("p").text();
+                item.title = $(eld).find("h3 a").text();
+                item.update = $(eld).find(".list-story-item-wrap-chapter").text();
+                item.updateLink = $(eld)
+                    .find(".list-story-item-wrap-chapter")
+                    .attr("href");
+                latestk.push(item);
+            });
+            let total = $(".panel_page_number .group_qty").find("a").text();
+            let linksk = [];
+            $(".panel_page_number .group_page a").each((y, elx) => {
+                let link = {};
+                link.text = $(elx).text();
+                link.href = $(elx).attr("href");
+                link.class = $(elx).attr("class");
+                linksk.push(link);
+            });
+
+            res.render("newloader", {
+                title: "Mirai",
+                latest: latestk,
+                total: total,
+                links: linksk,
+            });
+        })
+        .catch(err => {
+            console.error(err);
+            res.sendStatus(err.status || 500);
+        })
 };
 
 module.exports = {

--- a/controllers/search.controller.js
+++ b/controllers/search.controller.js
@@ -1,19 +1,24 @@
-const request = require("request");
+const fetch = require("node-fetch");
 const mangaPark = require("../utils/mangapark");
 const mangaParkObj = new mangaPark();
 
 const SearchController = (req, res, next) => {
-    try{
-        request(
-            "https://www.gogoanime1.com/search/topSearch?q=" + req.query.q,
-            (error, response, html) => {
-                res.send(response.body);
+    fetch("https://www.gogoanime1.com/search/topSearch?q=" + req.query.q)
+        .then(response => {
+            if (response.ok) {   // response.status >= 200 & < 300
+                return response.json(); // this API endpoint returns json
+            } else {
+                throw Error(response.statusText);
             }
-        );
-    }
-    catch(err){
-        console.log(err);
-    }
+        })
+        .then(json => {
+            res.send(json);
+        })
+        .catch(err => {
+            console.error(err);
+
+            res.sendStatus(err.status || 500)
+        })
 };
 
 const MangaSearchController = async (req, res, next) => {

--- a/controllers/stream.controller.js
+++ b/controllers/stream.controller.js
@@ -1,11 +1,18 @@
-const request = require("request");
+const fetch = require("node-fetch");
 const cheerio = require("cheerio");
 
 let navList = [];
 
 // Fetch Gogoanime latest header links
-request("https://www.gogoanime1.com", (error, response, html) => {
-    if (!error && response.statusCode == 200) {
+fetch("https://www.gogoanime1.com")
+    .then(response => {
+        if (response.ok) {   // response.status >= 200 & < 300
+            return response.text();
+        } else {
+            throw Error(response.statusText);
+        }
+    })
+    .then(html => {
         const $ = cheerio.load(html);
 
         $(".main-menu li").each((i, el) => {
@@ -14,84 +21,96 @@ request("https://www.gogoanime1.com", (error, response, html) => {
             link.text = $(el).find("a").text();
             navList.push(link);
         });
-    } else {
-        console.log(error);
-        
-    }
-});
+    })
+    .catch(err => {
+        console.error(err);
+    })
 
 const RenderPlayEpisode = (req, res, next) => {
-    try{
-        let url = req.query.url;
-        //generate series URL by exploding
-        let split = url.split("/");
-        let seriesUrl = split[0] + "//" + split[2] + "/" + split[3] + "/" + split[4];
-        //request Episode List
-        let episodeList = [];
-        request(seriesUrl, (error, response, html) => {
-            if (!error && response.statusCode == 200) {
-                const $ = cheerio.load(html);
-                //Get episodes list and links
-                let episodeDiv = $(".ci-contents").last(".check-list");
-                episodeDiv.find("li").each((i, el) => {
-                    let link = {};
-                    link.href = $(el).find("a").attr("href");
-                    link.episode = $(el).find("a").text();
-                    episodeList.push(link);
-                });
-                episodeList = episodeList.reverse();
-                //request current episode data
-                request(url, (error, response, html) => {
-                    if (!error && response.statusCode == 200) {
-                        const $ = cheerio.load(html);
-                        let detailsEpisode = {};
-                        detailsEpisode.name = $(".vmn-title").find("h1").text();
-                        detailsEpisode.downloadLink = $(".vmn-buttons")
-                            .children()
-                            .last()
-                            .attr("href");
-                        res.render("playepisode", {
-                            title: "Mirai",
-                            navList: navList,
-                            detailsEpisode: detailsEpisode,
-                            seriesUrl: seriesUrl,
-                            episodeList: episodeList,
-                            url: url,
-                        });
-                    } else {
-                        console.log(error);
-                    }
-                });
+    let url = req.query.url;
+    //generate series URL by exploding
+    let split = url.split("/");
+    let seriesUrl = split[0] + "//" + split[2] + "/" + split[3] + "/" + split[4];
+    //request Episode List
+    let episodeList = [];
+    fetch(seriesUrl)
+        .then(response => {
+            if (response.ok) {   // response.status >= 200 & < 300
+                return response.text();
             } else {
-                console.log(error);
+                throw Error(response.statusText);
             }
-        });
-    }
-    catch(err){
-        console.log(err);
-    }
+        })
+        .then(html => {
+            const $ = cheerio.load(html);
+            //Get episodes list and links
+            let episodeDiv = $(".ci-contents").last(".check-list");
+            episodeDiv.find("li").each((i, el) => {
+                let link = {};
+                link.href = $(el).find("a").attr("href");
+                link.episode = $(el).find("a").text();
+                episodeList.push(link);
+            });
+            episodeList = episodeList.reverse();
+            //request current episode data
+            fetch(url)
+                .then(response => {
+                    if (response.ok) {   // response.status >= 200 & < 300
+                        return response.text();
+                    } else {
+                        throw Error(response.statusText);
+                    }
+                })
+                .then(html => {
+                    const $ = cheerio.load(html);
+                    let detailsEpisode = {};
+                    detailsEpisode.name = $(".vmn-title").find("h1").text();
+                    detailsEpisode.downloadLink = $(".vmn-buttons")
+                        .children()
+                        .last()
+                        .attr("href");
+                    res.render("playepisode", {
+                        title: "Mirai",
+                        navList: navList,
+                        detailsEpisode: detailsEpisode,
+                        seriesUrl: seriesUrl,
+                        episodeList: episodeList,
+                        url: url,
+                    });
+                })
+                .catch(err => {
+                    console.error(err);
+                })
+        })
+        .catch(err => {
+            console.error(err);
+            res.sendStatus(err.status || 500);
+        })
 };
 
 const VideoURLController = (req, res) => {
-    try{
-        request(req.body.link, (error, response, html) => {
-            if (!error && response.statusCode == 200) {
-                const $ = cheerio.load(html);
-                let detailsEpisode = {};
-                detailsEpisode.name = $(".vmn-title").find("h1").text();
-                detailsEpisode.downloadLink = $(".vmn-buttons")
-                    .children()
-                    .last()
-                    .attr("href");
-                res.send(JSON.stringify(detailsEpisode));
+    fetch(req.body.link)
+        .then(response => {
+            if (response.ok) {   // response.status >= 200 & < 300
+                return response.text();
             } else {
-                console.log(error);
+                throw Error(response.statusText);
             }
-        });
-    }
-    catch(err){
-        console.log(err);
-    }
+        })
+        .then(html => {
+            const $ = cheerio.load(html);
+            let detailsEpisode = {};
+            detailsEpisode.name = $(".vmn-title").find("h1").text();
+            detailsEpisode.downloadLink = $(".vmn-buttons")
+                .children()
+                .last()
+                .attr("href");
+            res.send(JSON.stringify(detailsEpisode));
+        })
+        .catch(err => {
+            console.error(err);
+            res.sendStatus(err.status || 500);
+        })
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,17 +44,6 @@
       "resolved": "https://registry.npmjs.org/addr-to-ip-port/-/addr-to-ip-port-1.5.1.tgz",
       "integrity": "sha512-bA+dyydTNuQtrEDJ0g9eR7XabNhvrM5yZY0hvTbNK3yvoeC73ZqMES6E1cEqH9WPxs4uMtMsOjfwS4FmluhsAA=="
     },
-    "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
     "ansi-align": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -107,38 +96,10 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -156,14 +117,6 @@
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
         "safe-buffer": "5.1.2"
-      }
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "bencode": {
@@ -496,11 +449,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -623,14 +571,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "compact2string": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/compact2string/-/compact2string-1.4.1.tgz",
@@ -739,14 +679,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -779,11 +711,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -840,15 +767,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -937,26 +855,6 @@
         "vary": "~1.1.2"
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
     "filereader": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/filereader/-/filereader-0.10.3.tgz",
@@ -1017,21 +915,6 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -1084,14 +967,6 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -1150,20 +1025,6 @@
       "integrity": "sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw==",
       "dev": true
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1216,16 +1077,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -1396,52 +1247,16 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
     "js-base64": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.0.tgz",
       "integrity": "sha512-wVdUBYQeY2gY73RIlPrysvpYx+2vheGo8Y1SNQv/BzHToWpAZzJU7Z6uheKMAe+GLSBig5/Ps2nxg/8tRB73xg=="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
     },
     "junk": {
       "version": "2.1.0",
@@ -1745,6 +1560,11 @@
       "resolved": "https://registry.npmjs.org/next-event/-/next-event-1.0.0.tgz",
       "integrity": "sha1-53eKzeLlWALgrRh5w5z2917aYdg="
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-gyp-build": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
@@ -1814,11 +1634,6 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -1917,11 +1732,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -1956,11 +1766,6 @@
         "ipaddr.js": "1.9.0"
       }
     },
-    "psl": {
-      "version": "1.1.32",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
-    },
     "pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -1975,11 +1780,6 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -2128,33 +1928,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
-      }
-    },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
       }
     },
     "responselike": {
@@ -2387,22 +2160,6 @@
         "through": "2"
       }
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -2594,35 +2351,6 @@
         "nopt": "~1.0.10"
       }
     },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -2708,14 +2436,6 @@
         "xdg-basedir": "^4.0.0"
       }
     },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -2781,25 +2501,10 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "videostream": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "10.16.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "dev": "nodemon ./bin/www"
   },
   "engines": {
     "node": "10.16.0"
@@ -20,7 +21,7 @@
     "http-errors": "~1.6.3",
     "js-base64": "^3.6.0",
     "morgan": "~1.9.1",
-    "request": "^2.88.0",
+    "node-fetch": "^2.6.1",
     "webtorrent": "^0.103.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The request package was deprecated in [March 2019](https://github.com/request/request/issues/3142), and as such suggested alternatives to use for future projects, so i think it would be better shifting to the alternatives, before i start working on it, this change was a part of that, and i think this is good candidate for a PR too.

The choice of node-fetch is only one of the alternative libraries suggested, plus it's API is similar to the client side fetch function which is already supported by most current browsers.

There has been no visible changes on the client side in this PR though 🙂

> Apart from above, I added a "dev" script in package.json, since nodemon is listed as dev dependency, it's good to have a quick "yarn dev" command